### PR TITLE
Fixed Tile Map, Created Template, & ReadMe

### DIFF
--- a/Assets/Scenes/BlankTileMapTemplate.unity
+++ b/Assets/Scenes/BlankTileMapTemplate.unity
@@ -1,0 +1,398 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &16409901
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2573313240014089687, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_Name
+      value: PaintLayer1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4586530052141207177, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_Name
+      value: GrasslandsMacroPallet
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 89807af2ad289d9479f28060a414348b, type: 3}
+--- !u!1001 &1531268316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2573313240014089687, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_Name
+      value: PaintLayer1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4586530052141207177, guid: 89807af2ad289d9479f28060a414348b,
+        type: 3}
+      propertyPath: m_Name
+      value: GrasslandsDetailPallet
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 89807af2ad289d9479f28060a414348b, type: 3}
+--- !u!1 &1882873467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1882873469}
+  - component: {fileID: 1882873468}
+  - component: {fileID: 1882873470}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1882873468
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882873467}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1882873469
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882873467}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 1000, y: 13.36, z: 1000}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &1882873470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882873467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 1
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}

--- a/Assets/Scenes/BlankTileMapTemplate.unity.meta
+++ b/Assets/Scenes/BlankTileMapTemplate.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d4dc041bc798263458da74b3950eea9b
+guid: 441f728e5aad90e45909596e521716a1
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Scenes/Grasslands Maps/Dane'sLevel.unity
+++ b/Assets/Scenes/Grasslands Maps/Dane'sLevel.unity
@@ -133,7 +133,7 @@ PrefabInstance:
     - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 434283069270842645, guid: 89807af2ad289d9479f28060a414348b,
         type: 3}
@@ -213,75 +213,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 16409901}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &52466371
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 16409902}
-    m_Modifications:
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.8625073
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.70710677
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.70710677
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6486171222759734346, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_Name
-      value: HexTile1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
+--- !u!4 &16409903 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8921170127500659129, guid: 89807af2ad289d9479f28060a414348b,
+    type: 3}
+  m_PrefabInstance: {fileID: 16409901}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &104937494
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -351,7 +288,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 056adb71bde6db04a8e4aa4091ab9344, type: 3}
---- !u!1001 &263043487
+--- !u!1001 &126317939
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -361,7 +298,76 @@ PrefabInstance:
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.8624935
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6486171222759734346, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_Name
+      value: HexTile1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
+--- !u!1001 &253713355
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 16409902}
+    m_Modifications:
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
@@ -371,12 +377,81 @@ PrefabInstance:
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.4499948
+      value: 1.7250077
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6486171222759734346, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_Name
+      value: HexTile1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
+--- !u!1001 &335450165
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 16409903}
+    m_Modifications:
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000068575146
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.5000001
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
@@ -504,7 +579,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &407439800
+--- !u!1001 &415675544
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -514,12 +589,81 @@ PrefabInstance:
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.8625073
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6486171222759734346, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_Name
+      value: HexTile1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
+--- !u!1001 &575687876
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 16409902}
+    m_Modifications:
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
@@ -573,7 +717,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
---- !u!1001 &435217392
+--- !u!1001 &703269265
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -583,17 +727,17 @@ PrefabInstance:
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.5
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.5874946
+      value: 0.8625073
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
@@ -642,7 +786,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
---- !u!1001 &516017287
+--- !u!1001 &865045540
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -652,76 +796,7 @@ PrefabInstance:
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.724994
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.70710677
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.70710677
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6486171222759734346, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_Name
-      value: HexTile1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
---- !u!1001 &899493197
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 16409902}
-    m_Modifications:
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 10
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
@@ -780,7 +855,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
---- !u!1001 &1221312522
+--- !u!1001 &961225726
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -790,17 +865,17 @@ PrefabInstance:
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -1.5
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.7250077
+      value: -2.5874946
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
@@ -849,7 +924,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
---- !u!1001 &1242782885
+--- !u!1001 &1076981998
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -859,7 +934,76 @@ PrefabInstance:
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.4499948
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6486171222759734346, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_Name
+      value: HexTile1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
+--- !u!1001 &1396375918
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 16409902}
+    m_Modifications:
+    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
@@ -992,7 +1136,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 89807af2ad289d9479f28060a414348b, type: 3}
---- !u!1001 &1594568879
+--- !u!1001 &1724538404
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -1002,17 +1146,17 @@ PrefabInstance:
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.8624935
+      value: -1.724994
       objectReference: {fileID: 0}
     - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
         type: 3}
@@ -1154,7 +1298,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!114 &1882873470
 MonoBehaviour:
@@ -1176,72 +1320,3 @@ MonoBehaviour:
   m_ShadowLayerMask: 1
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
---- !u!1001 &2051680879
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 16409902}
-    m_Modifications:
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.8625073
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.70710677
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.70710677
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6486171222759734346, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_Name
-      value: HexTile1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}

--- a/Assets/Scenes/READ ME!!!!!!.txt
+++ b/Assets/Scenes/READ ME!!!!!!.txt
@@ -1,0 +1,91 @@
+READ ME!!!!!!
+
+This is instructions for how to use the TileMap Template & the TileMap brush.
+Please note: These instructions are ONLY for creating a Grey-Boxed enviornment to feed into our houdini tool. 
+DO NOT USE THIS FOR ANY OTHER LEVEL EDITING.
+
+
+------------------------------------------------
+|            Creating A New Scene              |------------------------------------------------------------
+------------------------------------------------
+
+	- Select & Copy (Ctrl D) the scene labeled: 'BlankTileMapTemplate' 
+		-This is located under Assets>Scenes
+
+	- Rename 'BlankTileMapTemplate1' with the following naming structure
+		Format:   [Biome]-[GreyBoxedFeature]-TileMap
+		Example1: GrassLands-Cliff-TileMap
+		Example2: Glacier-Cave-TileMap
+
+	- Move your TileMap to the corresponding biome folder located under Assets>Scenes
+
+
+------------------------------------------------
+|             Setting Up A New Map             |------------------------------------------------------------
+------------------------------------------------
+
+	- Make sure you have the 'Tile Palette' window located somewhere in your Unity Workspace
+	- If you do not have the 'Tile Palette' window:
+		- Navigate up to your menu bar and click on 'Window'
+		- Scroll down the Window drop menu and hover your cursor on '2D'
+		- Click on 'Tile Palette' 
+
+		/* If nothing pops up, you most likely already have the 'Tile Palette' window open.
+		   Its probably just hiding behind another window tab, like the '(i) Inspector' */
+
+	-In the 'Tile Palette' window, near the bottom, there is a drop down menu with the following options
+		
+		|--------------------|
+		|   Default Brush    |
+		|   Game Object Brush|
+		|   Group Brush      |
+		|   Line Brush       |
+		|   Random Brush     |
+		| * Prefab Brush     | We'll want to select the 'Prefab Brush'
+		|--------------------| Afterwards, we shouldn't be touching this selection
+	
+	- At the top of the'Tile Palette' window, click on the paint brush icon. 
+	- Decide whether you'll be painting with a macro brush or detail brush
+	- In your scene 'Hierarchy', locate the corresponding Pallet. 
+	- You will see a child under each Pallet labeled 'PaintLayer1'. This is what we want to paint on.
+	
+	- DO NOT PAINT ON THE PALLET PARENT.
+	
+	/* Note: The Directional Light is located super far away. DO NOT MOVE IT CLOSER TO THE ORIGIN
+           This will cause problems with the paint brush. */
+	
+	- Paint to your hearts content
+	- The eraser brush does not work. You will need to manually select tiles you want to delete.
+
+
+------------------------------------------------
+|        Exporting Your Map for Houdini        |------------------------------------------------------------
+------------------------------------------------
+ 
+	- Once you're done painting. Select BOTH Pallets with CTRL L-Click.
+	- DO NOT SELECT THESE WITH SHIFT CLICK! This will select all children of the upper pallet.
+	- DO NOT SELECT ANY CHILDREN OF THE PALLETS!
+	- Navigate to the menu bar and click 'GameObject'
+	- Click on 'Export To FBX'
+	
+	- In the 'Export Options' window, fill out and select the following.
+		
+		Export Name: this should follow a similar format to what you named your scene
+			~ [Biome]-[GreyBoxedFeature]-GreyBox
+		Export path should be 'Assets/Scenes/Unity_to_Houdini_FBX_Mesh
+		
+		Transfer Animation should be non-selectable.
+		
+		Options V
+		Export Format: ---------------- ASCII
+		Include: -------------- Model(s) Only
+		LOD Level: --------------- All Levels
+		Object(s) Position: -- World Absolute
+		Animated Skinned Mesh: ---- Unchecked
+		Compatible Naming: ---------- Checked
+		Export Unrendered: ---------- Checked
+		Preserve Import Settings: - Unchecked
+
+	- Export
+	- Either Send Dane the FBX via Discord, or Push your branch to Dev and notify Dane.
+	- Thanks for reading me! :)

--- a/Assets/Scenes/READ ME!!!!!!.txt.meta
+++ b/Assets/Scenes/READ ME!!!!!!.txt.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: d4dc041bc798263458da74b3950eea9b
-DefaultImporter:
+guid: e41138b19779e254d8935be745d04fa8
+TextScriptImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/TileMap/EnviornmentPrefabs/New Palette.prefab
+++ b/Assets/TileMap/EnviornmentPrefabs/New Palette.prefab
@@ -29,8 +29,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7618344841542689352}
+  m_Children: []
   m_Father: {fileID: 434283069270842645}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -166,86 +165,6 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 1
   m_CellSwizzle: 2
---- !u!1001 &4103235236657153208
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 8921170127500659129}
-    m_Modifications:
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.000068604946
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.49999997
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.70710677
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.70710677
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6486171222759734346, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_Name
-      value: HexTile1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7475051086873275934, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-        type: 3}
-      propertyPath: m_DynamicOccludee
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2c34d7e3b216ec5479377f9fe53757aa, type: 3}
---- !u!4 &7618344841542689352 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5857022507185612528, guid: 2c34d7e3b216ec5479377f9fe53757aa,
-    type: 3}
-  m_PrefabInstance: {fileID: 4103235236657153208}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &9024332007407720166
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
I removed the child of PaintLayer1 that was baked into the prefab as to not have a permanent hex at the origin of the map. I also moved the Directional Light far far away to remove any issues it causes with the ray cast to the tile map. I saved all of these changes and labeled this new scene as a template for our level designers to simply copy, rename, and get started. I also created a README with detailed instructions on how to get started, details on what problems they may run into, and how to export the map as an FBX.